### PR TITLE
.github: Reduce unnecessary executions of the benchmark CI

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -3,9 +3,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'crates/lazycsv/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'crates/lazycsv/**'
+
+# Allow only one set of CI to run at a time per PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   deployments: write


### PR DESCRIPTION
- Modified it to run only when there are changes to lazycsv
- Ensured that no more than one benchmark runs at a time